### PR TITLE
Support specifying a function to choose the url

### DIFF
--- a/telefunc/client/clientConfig.ts
+++ b/telefunc/client/clientConfig.ts
@@ -1,17 +1,28 @@
 export { configUser as config }
 export { resolveClientConfig }
+export type { CallContext }
 
 import { assertUsage } from './utils'
+
+type CallContext = {
+  telefuncUrl: string
+  httpRequestBody: string
+  telefunctionName: string
+  telefuncFilePath: string
+  httpHeaders: Record<string, string> | null
+}
+
+type TeleFuncUrl = string | ((ctx: CallContext) => string)
 
 /** Telefunc Client Configuration */
 type ConfigUser = {
   /** The Telefunc HTTP endpoint URL, e.g. `https://example.org/_telefunc`. Default: `/_telefunc`. */
-  telefuncUrl?: string
+  telefuncUrl?: TeleFuncUrl,
   /** Additional headers sent along Telefunc HTTP requests */
   httpHeaders?: Record<string, string>
 }
 type ConfigResolved = {
-  telefuncUrl: string
+  telefuncUrl: TeleFuncUrl
   httpHeaders: Record<string, string> | null
 }
 
@@ -26,12 +37,14 @@ function resolveClientConfig(): ConfigResolved {
 
 function validateUserConfig(configUserUnwrapped: ConfigUser, prop: string, val: unknown) {
   if (prop === 'telefuncUrl') {
-    assertUsage(typeof val === 'string', 'config.telefuncUrl should be a string')
-    const isIpAddress = (value: string) => /^\d/.test(value)
-    assertUsage(
-      val.startsWith('/') || val.startsWith('http') || isIpAddress(val),
-      `Setting \`config.telefuncUrl\` to \`${val}\` but it should be one of the following: a URL pathname (e.g. \`/_telefunc\`), a URL with origin (e.g. \`https://example.org/_telefunc\`), or an IP address (e.g. \`192.158.1.38\`).`
-    )
+    if (typeof val !== 'function') {
+        assertUsage(typeof val === 'string', 'config.telefuncUrl should be a string')
+        const isIpAddress = (value: string) => /^\d/.test(value)
+        assertUsage(
+            val.startsWith('/') || val.startsWith('http') || isIpAddress(val),
+            `Setting \`config.telefuncUrl\` to \`${val}\` but it should be one of the following: a URL pathname (e.g. \`/_telefunc\`), a URL with origin (e.g. \`https://example.org/_telefunc\`), or an IP address (e.g. \`192.158.1.38\`).`
+        )
+    }
     configUserUnwrapped[prop] = val
   } else if (prop === 'httpHeaders') {
     assertUsage(

--- a/telefunc/client/remoteTelefunctionCall/makeHttpRequest.ts
+++ b/telefunc/client/remoteTelefunctionCall/makeHttpRequest.ts
@@ -3,6 +3,7 @@ export { makeHttpRequest }
 import { parse } from '@brillout/json-serializer/parse'
 import { assert, assertUsage, isObject, objectAssign } from '../utils'
 import { callOnAbortListeners } from './onAbort'
+import type { CallContext } from '../clientConfig'
 
 const method = 'POST'
 const STATUS_CODE_SUCCESS = 200
@@ -10,16 +11,11 @@ const STATUS_CODE_ABORT = 403
 const STATUS_CODE_BUG = 500
 const STATUS_CODE_INVALID = 400
 
-async function makeHttpRequest(callContext: {
-  telefuncUrl: string
-  httpRequestBody: string
-  telefunctionName: string
-  telefuncFilePath: string
-  httpHeaders: Record<string, string> | null
-}): Promise<{ telefunctionReturn: unknown }> {
+async function makeHttpRequest(callContext: CallContext): Promise<{ telefunctionReturn: unknown }> {
   let response: Response
   try {
-    response = await fetch(callContext.telefuncUrl, {
+    const url = typeof callContext.telefuncUrl === 'string' ? callContext.telefuncUrl : callContext.telefuncUrl(callContext)
+    response = await fetch(url, {
       method,
       body: callContext.httpRequestBody,
       credentials: 'same-origin',


### PR DESCRIPTION
This will allow dynamically choosing the url at call time.

My use case for this is that my backend is AWS lambda, where each "telefunc.ts" file being bundled into a separate lambda and hosted in cloud front at different urls.

This is an early PR to gain feedback before I add more tests and cleanup some more, I'm not sure if this is the best approach.  Happy to change it if you have suggestions.

Alternatively, I'd be happy to implement #60 which would would support the same behavior.