### PR TITLE
new config: `generateShieldInDev`

### DIFF
--- a/telefunc/node/server/serverConfig.ts
+++ b/telefunc/node/server/serverConfig.ts
@@ -23,6 +23,8 @@ type ConfigUser = {
   root?: string
   /** Wether to disable ETag cache headers */
   disableEtag?: boolean
+  /** Wether to generate shield during development time */
+  generateShieldInDev?: boolean
 }
 type ConfigResolved = {
   telefuncUrl: string
@@ -30,6 +32,7 @@ type ConfigResolved = {
   disableEtag: boolean
   telefuncFiles: string[] | null
   disableNamingConvention: boolean
+  generateShieldInDev: boolean
 }
 
 const configUser: ConfigUser = new Proxy({}, { set: validateUserConfig })
@@ -38,6 +41,7 @@ function getServerConfig(): ConfigResolved {
   return {
     disableEtag: configUser.disableEtag ?? false,
     disableNamingConvention: configUser.disableNamingConvention ?? false,
+    generateShieldInDev: configUser.generateShieldInDev ?? false,
     telefuncUrl: configUser.telefuncUrl || '/_telefunc',
     telefuncFiles: (() => {
       if (configUser.telefuncFiles) {
@@ -81,6 +85,9 @@ function validateUserConfig(configUserUnwrapped: ConfigUser, prop: string, val: 
     configUserUnwrapped[prop] = val
   } else if (prop === 'disableNamingConvention') {
     assertUsage(typeof val === 'boolean', '`config.disableNamingConvention` should be a boolean')
+    configUserUnwrapped[prop] = val
+  } else if (prop === 'generateShieldInDev') {
+    assertUsage(typeof val === 'boolean', '`config.generateShieldInDev` should be a boolean')
     configUserUnwrapped[prop] = val
   } else {
     assertUsage(false, `Unknown config.${prop}`)

--- a/telefunc/node/server/shield/codegen/generateShield.ts
+++ b/telefunc/node/server/shield/codegen/generateShield.ts
@@ -84,7 +84,7 @@ function getProject(telefuncFilePath: string, telefuncFileCode: string, appRootD
     path.dirname(telefuncFilePath),
     `__telefunc_shieldGen_${path.basename(telefuncFilePath)}`,
   )
-  const shieldGenSource = project.createSourceFile(shieldGenFilePath)
+  const shieldGenSource = project.createSourceFile(shieldGenFilePath, undefined, { overwrite: true })
   shieldGenSource.addImportDeclaration({
     moduleSpecifier: getImportPath(shieldGenFilePath, typeToShieldFilePath),
     namedImports: ['ShieldArrStr'],

--- a/telefunc/node/transformer/transformTelefuncFileServerSide.ts
+++ b/telefunc/node/transformer/transformTelefuncFileServerSide.ts
@@ -3,6 +3,7 @@ export { transformTelefuncFileServerSide }
 import { getExportNames } from './getExportNames'
 import { assertPosixPath } from './utils'
 import { generateShield } from '../server/shield/codegen/generateShield'
+import { getServerConfig } from '../server/serverConfig'
 
 async function transformTelefuncFileServerSide(
   src: string,
@@ -17,7 +18,9 @@ async function transformTelefuncFileServerSide(
   const exportNames = await getExportNames(src)
   let code = decorateTelefunctions(exportNames, src, id.replace(appRootDir, ''), appRootDir, skipRegistration)
 
-  if (id.endsWith('.ts') && !isDev) {
+  const { generateShieldInDev } = getServerConfig() 
+
+  if (id.endsWith('.ts') && (!isDev || generateShieldInDev)) {
     code = generateShield(code, id, appRootDir)
   }
 


### PR DESCRIPTION
Over the last months I've ran into a handful more bugs in my project that were basically caused by me not finding them in local development because telefunc does not apply shields in local dev. Thats why I want to enable shields in dev to not have ugly surprises in prod. This addresses https://github.com/brillout/telefunc/issues/78 which was my underlying issue to propose https://github.com/brillout/telefunc/issues/81 

I understand that the shield generation takes some time but after testing it in my project on my machine it was not really noticeable, and I gladly eat that caveat if it becomes more noticeable as the project grows.

Next thing I would do if you are cool with the approach is to add it to the docs.