### PR TITLE
`typeToShield.ts` error upon upgrade typescript

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 0.5.33(encoding@0.1.13)
       '@brillout/test-types':
         specifier: ^0.1.13
-        version: 0.1.13(typescript@5.4.4)
+        version: 0.1.13(typescript@5.5.2)
       prettier:
         specifier: ^2.8.7
         version: 2.8.7
@@ -199,7 +199,7 @@ importers:
         version: 3.21.0
       nuxt:
         specifier: 2.17.3
-        version: 2.17.3(acorn@8.11.2)(consola@3.2.3)(encoding@0.1.13)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.4.4)(vue@2.7.16)
+        version: 2.17.3(acorn@8.11.2)(consola@3.2.3)(encoding@0.1.13)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.5.2)(vue@2.7.16)
       sass-loader:
         specifier: ^10.4.1
         version: 10.5.2(webpack@4.46.0)
@@ -410,8 +410,8 @@ importers:
         specifier: ^2.67.1
         version: 2.67.1
       typescript:
-        specifier: ^4.8.4
-        version: 4.8.4
+        specifier: ^5.5.2
+        version: 5.5.2
       vite:
         specifier: ^3.2.2
         version: 3.2.2(terser@5.10.0)
@@ -9553,11 +9553,6 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=}
 
-  typescript@4.8.4:
-    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-
   typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
@@ -9580,6 +9575,11 @@ packages:
 
   typescript@5.4.4:
     resolution: {integrity: sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.5.2:
+    resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -12089,12 +12089,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@brillout/test-types@0.1.13(typescript@5.4.4)':
+  '@brillout/test-types@0.1.13(typescript@5.5.2)':
     dependencies:
       '@brillout/picocolors': 1.0.12
       fast-glob: 3.2.12
       source-map-support: 0.5.21
-      typescript: 5.4.4
+      typescript: 5.5.2
 
   '@brillout/vite-plugin-server-entry@0.4.2':
     dependencies:
@@ -12995,12 +12995,12 @@ snapshots:
       - supports-color
       - vue
 
-  '@nuxt/builder@2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.4.4)(vue@2.7.16)':
+  '@nuxt/builder@2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.5.2)(vue@2.7.16)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/utils': 2.17.3
       '@nuxt/vue-app': 2.17.3
-      '@nuxt/webpack': 2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.4.4)(vue@2.7.16)
+      '@nuxt/webpack': 2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.5.2)(vue@2.7.16)
       chalk: 4.1.2
       chokidar: 3.5.3
       consola: 3.2.3
@@ -13295,7 +13295,7 @@ snapshots:
       vue-meta: 2.4.0
       vue-server-renderer: 2.7.16
 
-  '@nuxt/webpack@2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.4.4)(vue@2.7.16)':
+  '@nuxt/webpack@2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.5.2)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.24.6
       '@nuxt/babel-preset-app': 2.17.3(vue@2.7.16)
@@ -13318,7 +13318,7 @@ snapshots:
       memory-fs: 0.5.0
       optimize-css-assets-webpack-plugin: 6.0.1(webpack@4.47.0)
       pify: 5.0.0
-      pnp-webpack-plugin: 1.7.0(typescript@5.4.4)
+      pnp-webpack-plugin: 1.7.0(typescript@5.5.2)
       postcss: 8.4.35
       postcss-import: 15.1.0(postcss@8.4.35)
       postcss-import-resolver: 2.0.0
@@ -16126,8 +16126,8 @@ snapshots:
       '@typescript-eslint/parser': 5.51.0(eslint@8.47.0)(typescript@5.1.6)
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0)
+      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.29.0)(eslint@8.47.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3)(eslint@8.47.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.47.0)
       eslint-plugin-react: 7.33.2(eslint@8.47.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.47.0)
@@ -16145,12 +16145,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0):
+  eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0)(eslint@8.47.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.47.0
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3)(eslint@8.47.0)
       get-tsconfig: 4.4.0
       globby: 13.1.3
       is-core-module: 2.13.1
@@ -16159,18 +16159,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0)(eslint@8.47.0))(eslint@8.47.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.51.0(eslint@8.47.0)(typescript@5.1.6)
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0)
+      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.29.0)(eslint@8.47.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0):
+  eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3)(eslint@8.47.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -16180,7 +16180,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0)(eslint@8.47.0))(eslint@8.47.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -18790,10 +18790,10 @@ snapshots:
 
   number-is-nan@1.0.1: {}
 
-  nuxt@2.17.3(acorn@8.11.2)(consola@3.2.3)(encoding@0.1.13)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.4.4)(vue@2.7.16):
+  nuxt@2.17.3(acorn@8.11.2)(consola@3.2.3)(encoding@0.1.13)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.5.2)(vue@2.7.16):
     dependencies:
       '@nuxt/babel-preset-app': 2.17.3(vue@2.7.16)
-      '@nuxt/builder': 2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.4.4)(vue@2.7.16)
+      '@nuxt/builder': 2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.5.2)(vue@2.7.16)
       '@nuxt/cli': 2.17.3
       '@nuxt/components': 2.2.1(consola@3.2.3)
       '@nuxt/config': 2.17.3
@@ -18806,7 +18806,7 @@ snapshots:
       '@nuxt/utils': 2.17.3
       '@nuxt/vue-app': 2.17.3
       '@nuxt/vue-renderer': 2.17.3
-      '@nuxt/webpack': 2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.4.4)(vue@2.7.16)
+      '@nuxt/webpack': 2.17.3(acorn@8.11.2)(handlebars@4.7.7)(prettier@2.8.7)(typescript@5.5.2)(vue@2.7.16)
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - acorn
@@ -19226,9 +19226,9 @@ snapshots:
 
   pngjs@6.0.0: {}
 
-  pnp-webpack-plugin@1.7.0(typescript@5.4.4):
+  pnp-webpack-plugin@1.7.0(typescript@5.5.2):
     dependencies:
-      ts-pnp: 1.2.0(typescript@5.4.4)
+      ts-pnp: 1.2.0(typescript@5.5.2)
     transitivePeerDependencies:
       - typescript
 
@@ -20962,8 +20962,8 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.58.0
-      svelte-preprocess: 5.0.3(@babel/core@7.24.6)(postcss-load-config@2.1.2)(postcss@8.4.35)(svelte@3.58.0)(typescript@5.3.3)
-      typescript: 5.3.3
+      svelte-preprocess: 5.0.3(@babel/core@7.24.6)(postcss-load-config@2.1.2)(postcss@8.4.35)(svelte@3.58.0)(typescript@5.4.4)
+      typescript: 5.4.4
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -20993,7 +20993,7 @@ snapshots:
       postcss-load-config: 2.1.2
       typescript: 5.0.3
 
-  svelte-preprocess@5.0.3(@babel/core@7.24.6)(postcss-load-config@2.1.2)(postcss@8.4.35)(svelte@3.58.0)(typescript@5.3.3):
+  svelte-preprocess@5.0.3(@babel/core@7.24.6)(postcss-load-config@2.1.2)(postcss@8.4.35)(svelte@3.58.0)(typescript@5.4.4):
     dependencies:
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
@@ -21005,7 +21005,7 @@ snapshots:
       '@babel/core': 7.24.6
       postcss: 8.4.35
       postcss-load-config: 2.1.2
-      typescript: 5.3.3
+      typescript: 5.4.4
 
   svelte@3.58.0: {}
 
@@ -21217,9 +21217,9 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.3.62(@swc/helpers@0.5.2)
 
-  ts-pnp@1.2.0(typescript@5.4.4):
+  ts-pnp@1.2.0(typescript@5.5.2):
     optionalDependencies:
-      typescript: 5.4.4
+      typescript: 5.5.2
 
   tsconfig-paths@3.14.2:
     dependencies:
@@ -21306,8 +21306,6 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@4.8.4: {}
-
   typescript@4.9.5: {}
 
   typescript@5.0.3: {}
@@ -21317,6 +21315,8 @@ snapshots:
   typescript@5.3.3: {}
 
   typescript@5.4.4: {}
+
+  typescript@5.5.2: {}
 
   ua-parser-js@1.0.37: {}
 

--- a/telefunc/package.json
+++ b/telefunc/package.json
@@ -91,7 +91,7 @@
     "next": "^12.0.8",
     "react-streaming": "^0.3.22",
     "rollup": "^2.67.1",
-    "typescript": "^4.8.4",
+    "typescript": "^5.5.2",
     "vite": "^3.2.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi @louwers, I'm trying to upgrade to TypeScript `5.5.2` but I get following error about `typeToShield.ts`.

![image](https://github.com/brillout/telefunc/assets/1005638/4b88ba8f-c8a7-456f-ab71-5368bbaad2c8)

Do you have a suggestion for how to solve it?

I hope you're well!