### PR TITLE
docs: fix typos and clarify website text

### DIFF
--- a/docs/pages/RPC-vs-GraphQL-REST/+Page.mdx
+++ b/docs/pages/RPC-vs-GraphQL-REST/+Page.mdx
@@ -96,7 +96,7 @@ This means that the frontend developers need to make changes to the Node.js serv
 If we are a small team of full-stack developers, then such frontend-backend coupling is not a problem.
 But, as we grow, we may want to have a frontend team that develops independently of a backend team.
 
-We can achieve a decoupling by using a Telefunc Server: a dedicated Node.js server with sole purpose of serving telefunctions.
+We can achieve a decoupling by using a Telefunc Server: a dedicated Node.js server with the sole purpose of serving telefunctions.
 
 The frontend and the Telefunc server are developed & deployed hand-in-hand,
 while the backend (another Node.js server, Ruby on Rails, ...) can be developed & deployed independently.
@@ -135,7 +135,7 @@ not only the frontend developers but also the backend developers:
 the backend developers then also use the GraphQL API instead of directly accessing our databases.
 
 A GraphQL API enables an independent database development
-which can become crucial strategy at scale.
+which can become a crucial strategy at scale.
 
 > GraphQL is the state-of-the-art for this use case;
 > a RESTful API would be too limiting.
@@ -152,6 +152,6 @@ Also, RPC is a natural fit for the increasingly ubiquitous practice of full-stac
 On the other hand, we need GraphQL/REST if we need to
 give third parties access to our database.
 
-Also, using a GraphQL API can be crucial strategy for very large companies with highly complex databases.
+Also, using a GraphQL API can be a crucial strategy for very large companies with highly complex databases.
 
 In general, a sensible default is to start with RPC and use GraphQL/REST only when the need arises.

--- a/docs/pages/RPC/+Page.mdx
+++ b/docs/pages/RPC/+Page.mdx
@@ -387,6 +387,8 @@ export async function onNewTodo({ text, isCompleted }) {
 
 Not only does `shield()` call `throw Abort()` on our behalf, but it also infers the type of the arguments for TypeScript and IntelliSense.
 
+<Link href="/shield#typescript-automatic">When using TypeScript, Telefunc can automatically generate `shield()` for each telefunction.</Link>
+
 
 ## Random telefunction calls
 

--- a/docs/pages/RPC/+Page.mdx
+++ b/docs/pages/RPC/+Page.mdx
@@ -227,7 +227,7 @@ while the browser-side can remotely call it in a seamless fashion.
 
 Your telefunctions can be remotely called not only by your frontend, but by anyone.
 
-For example, anyone can call the `hello()` telefunction we've seen in the previous section by opening a Linux terminal and make this HTTP request:
+For example, anyone can call the `hello()` telefunction we've seen in the previous section by opening a Linux terminal and making this HTTP request:
 
 ```bash
 curl https://your-website.com/_telefunc --data '{

--- a/docs/pages/abort-vs-error/+Page.mdx
+++ b/docs/pages/abort-vs-error/+Page.mdx
@@ -2,7 +2,7 @@ import { Link, ReadingRecommendation } from '@brillout/docpress'
 
 <ReadingRecommendation links={['/RPC']} />
 
-You may wonder, why not using `throw new Error()` instead of `throw Abort()`?
+You may wonder, why not use `throw new Error()` instead of `throw Abort()`?
 
 ```js
 // TodoList.telefunc.js

--- a/docs/pages/event-based/+Page.mdx
+++ b/docs/pages/event-based/+Page.mdx
@@ -120,7 +120,7 @@ We also recommend to collocate `.telefunc.js` files with UI component files:
 ❌  pages/edit/all.telefunc.js
 ```
 
-First time Telefunc users often create generic telefunctions out of the habit of using REST/GraphQL, but defining tailored telefunctions instead is usually the better appraoch as explained above.
+First-time Telefunc users often create generic telefunctions out of the habit of using REST/GraphQL, but defining tailored telefunctions instead is usually the better approach as explained above.
 
 Telefunc displays a warning whenever the naming convention isn't followed. You can remove the warning with <Link text={<code>config.disableNamingConvention</code>} href="/disableNamingConvention" />.
 

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -38,15 +38,15 @@ import { telefunc } from 'telefunc'
 // Telefunc middleware
 app.all('/_telefunc', async (req, res) => {
   // Authentication middlewares (e.g. Passport.js or Grant) usually provide information
-  // about the logged-in user on the `req` object.
+  // about the logged-in user on the `req` object:
   const user = req.user
   // Or when using a third-party authentication provider (e.g. Auth0):
   const user = await authProviderApi.getUser(req.headers)
 
   const httpResponse = await telefunc({
-    // We provide the context object here
+    // We provide the context object here:
     context: {
-      user
+      user,
     },
     url: req.url,
     method: req.method,

--- a/docs/pages/getContext/+Page.mdx
+++ b/docs/pages/getContext/+Page.mdx
@@ -26,7 +26,7 @@ It's most commonly used for implementing permissions, see <Link href="/permissio
 
 ## Provide
 
-Before we can use `getContext()`, we need to provide the `contex` object to <Link text="Telefunc's Server Middleware" href="/telefunc" />:
+Before we can use `getContext()`, we need to provide the `context` object to <Link text="Telefunc's Server Middleware" href="/telefunc" />:
 
 ```js
 // server.js
@@ -69,19 +69,19 @@ If you get this error:
 ```
 </CodeBlockTransformer>
 
-Then this means called `getContext()` after an `await` operator:
+Then this means that `getContext()` was called after an `await` operator:
 
 ```js
 // TodoList.telefunc.js
 
 export async function myTelefunction() {
-  await someting()
+  await something()
   // ❌ Bad: we should call getContext() before `await something()`
   const context = getContext()
 }
 ```
 
-Make sure to call getContext() before any `await` operator:
+Make sure to call `getContext()` before any `await` operators:
 
 ```js
 // TodoList.telefunc.js
@@ -89,7 +89,7 @@ Make sure to call getContext() before any `await` operator:
 export async function myTelefunction() {
   // ✅ Good: we call getContext() before `await`
   const context = getContext()
-  await someting()
+  await something()
 }
 ```
 

--- a/docs/pages/index/CodePreviewBlockLeft.mdx
+++ b/docs/pages/index/CodePreviewBlockLeft.mdx
@@ -9,7 +9,7 @@ export { onNewTodo }
 import { getContext } from 'telefunc'
 
 // Telefunction arguments are automatically validated
-// at runtime: `text` is guaranteed to be a string.
+// at runtime, so `text` is guaranteed to be a string.
 async function onNewTodo(text: string) {
   const { user } = getContext()
 

--- a/docs/pages/index/CodePreviewBlockRight.mdx
+++ b/docs/pages/index/CodePreviewBlockRight.mdx
@@ -2,8 +2,8 @@
 // CreateTodo.tsx
 // Environment: client
 
-// CreateTodo.telefunc.ts isn't actually loaded: Tele-
-// func transforms it into a thin HTTP client.
+// CreateTodo.telefunc.ts isn't actually loaded;
+// Telefunc transforms it into a thin HTTP client.
 import { onNewTodo } from './CreateTodo.telefunc.ts'
 
 async function onClick(form) {


### PR DESCRIPTION
Rationale for the 2nd and 3rd commits are included in the commit messages.

Unsolicited PR, so feel free to disagree with the changes.