### PR TITLE
use Vite 6

### DIFF
--- a/examples/authentication/package.json
+++ b/examples/authentication/package.json
@@ -26,7 +26,7 @@
     "typescript": "^5.7.2",
     "vike": "^0.4.206",
     "vike-node": "^0.2.1",
-    "vite": "^5.4.11"
+    "vite": "^6.0.2"
   },
   "type": "module",
   "imports": {

--- a/examples/authentication/package.json
+++ b/examples/authentication/package.json
@@ -25,7 +25,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.7.2",
     "vike": "^0.4.206",
-    "vike-node": "^0.2.1",
+    "vike-node": "^0.2.2",
     "vite": "^6.0.2"
   },
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
         version: 0.3.0
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2)))
+        version: 4.3.4(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0))
       cookie-parser:
         specifier: ^1.4.7
         version: 1.4.7
@@ -118,13 +118,13 @@ importers:
         version: 5.7.2
       vike:
         specifier: ^0.4.206
-        version: 0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2)))
+        version: 0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0))
       vike-node:
         specifier: ^0.2.1
-        version: 0.2.1(encoding@0.1.13)(vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2))))(vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2)))
+        version: 0.2.1(encoding@0.1.13)(vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0))
       vite:
-        specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2))
+        specifier: ^6.0.2
+        version: 6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)
 
   examples/babel:
     dependencies:
@@ -10751,37 +10751,6 @@ packages:
       terser:
         optional: true
 
-  vite@5.4.11:
-    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
   vite@5.4.6:
     resolution: {integrity: sha512-IeL5f8OO5nylsgzd9tq4qD2QqI0k2CQLGrWD0rCN0EQJZpBK5vJAx0I+GDkMOXxQX/OfFHMuLIx6ddAxGX/k+Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -10811,6 +10780,46 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vite@6.0.2:
+    resolution: {integrity: sha512-XdQ+VsY2tJpBsKGs0wf3U/+azx8BBpYRHFAyKm5VeEZNOJZRB63q7Sc8Iup3k0TrN3KO6QgyzFf+opSbfY1y0g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vitefu@0.2.4:
@@ -11236,7 +11245,7 @@ snapshots:
   '@babel/code-frame@7.24.6':
     dependencies:
       '@babel/highlight': 7.24.6
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -11833,7 +11842,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.6
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   '@babel/parser@7.17.3':
     dependencies:
@@ -14712,7 +14721,7 @@ snapshots:
       cross-spawn: 7.0.3
       is-glob: 4.0.3
       open: 8.4.1
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       tiny-glob: 0.2.9
       tslib: 2.5.0
 
@@ -14982,7 +14991,7 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   '@types/anymatch@3.0.0':
     dependencies:
@@ -15421,14 +15430,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2)))':
+  '@vitejs/plugin-react@4.3.4(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2))
+      vite: 6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15970,7 +15979,7 @@ snapshots:
       caniuse-lite: 1.0.30001621
       fraction.js: 4.3.7
       normalize-range: 0.1.2
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
@@ -16868,9 +16877,9 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.1.0
 
-  css-declaration-sorter@6.4.1(postcss@8.4.35):
+  css-declaration-sorter@6.4.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
 
   css-declaration-sorter@7.2.0(postcss@8.4.35):
     dependencies:
@@ -16885,13 +16894,13 @@ snapshots:
 
   css-loader@5.2.7(webpack@4.47.0):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.35)
+      icss-utils: 5.1.0(postcss@8.4.49)
       loader-utils: 2.0.4
-      postcss: 8.4.35
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.35)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.35)
-      postcss-modules-scope: 3.2.0(postcss@8.4.35)
-      postcss-modules-values: 4.0.0(postcss@8.4.35)
+      postcss: 8.4.49
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.49)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.49)
+      postcss-modules-scope: 3.2.0(postcss@8.4.49)
+      postcss-modules-values: 4.0.0(postcss@8.4.49)
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.1
       semver: 7.6.0
@@ -16925,12 +16934,12 @@ snapshots:
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
-      source-map-js: 1.0.2
+      source-map-js: 1.2.1
 
   css-tree@2.3.1:
     dependencies:
       mdn-data: 2.0.30
-      source-map-js: 1.0.2
+      source-map-js: 1.2.1
 
   css-what@5.1.0: {}
 
@@ -16940,38 +16949,38 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@5.2.14(postcss@8.4.35):
+  cssnano-preset-default@5.2.14(postcss@8.4.49):
     dependencies:
-      css-declaration-sorter: 6.4.1(postcss@8.4.35)
-      cssnano-utils: 3.1.0(postcss@8.4.35)
-      postcss: 8.4.35
-      postcss-calc: 8.2.4(postcss@8.4.35)
-      postcss-colormin: 5.3.1(postcss@8.4.35)
-      postcss-convert-values: 5.1.3(postcss@8.4.35)
-      postcss-discard-comments: 5.1.2(postcss@8.4.35)
-      postcss-discard-duplicates: 5.1.0(postcss@8.4.35)
-      postcss-discard-empty: 5.1.1(postcss@8.4.35)
-      postcss-discard-overridden: 5.1.0(postcss@8.4.35)
-      postcss-merge-longhand: 5.1.7(postcss@8.4.35)
-      postcss-merge-rules: 5.1.4(postcss@8.4.35)
-      postcss-minify-font-values: 5.1.0(postcss@8.4.35)
-      postcss-minify-gradients: 5.1.1(postcss@8.4.35)
-      postcss-minify-params: 5.1.4(postcss@8.4.35)
-      postcss-minify-selectors: 5.2.1(postcss@8.4.35)
-      postcss-normalize-charset: 5.1.0(postcss@8.4.35)
-      postcss-normalize-display-values: 5.1.0(postcss@8.4.35)
-      postcss-normalize-positions: 5.1.1(postcss@8.4.35)
-      postcss-normalize-repeat-style: 5.1.1(postcss@8.4.35)
-      postcss-normalize-string: 5.1.0(postcss@8.4.35)
-      postcss-normalize-timing-functions: 5.1.0(postcss@8.4.35)
-      postcss-normalize-unicode: 5.1.1(postcss@8.4.35)
-      postcss-normalize-url: 5.1.0(postcss@8.4.35)
-      postcss-normalize-whitespace: 5.1.1(postcss@8.4.35)
-      postcss-ordered-values: 5.1.3(postcss@8.4.35)
-      postcss-reduce-initial: 5.1.2(postcss@8.4.35)
-      postcss-reduce-transforms: 5.1.0(postcss@8.4.35)
-      postcss-svgo: 5.1.0(postcss@8.4.35)
-      postcss-unique-selectors: 5.1.1(postcss@8.4.35)
+      css-declaration-sorter: 6.4.1(postcss@8.4.49)
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-calc: 8.2.4(postcss@8.4.49)
+      postcss-colormin: 5.3.1(postcss@8.4.49)
+      postcss-convert-values: 5.1.3(postcss@8.4.49)
+      postcss-discard-comments: 5.1.2(postcss@8.4.49)
+      postcss-discard-duplicates: 5.1.0(postcss@8.4.49)
+      postcss-discard-empty: 5.1.1(postcss@8.4.49)
+      postcss-discard-overridden: 5.1.0(postcss@8.4.49)
+      postcss-merge-longhand: 5.1.7(postcss@8.4.49)
+      postcss-merge-rules: 5.1.4(postcss@8.4.49)
+      postcss-minify-font-values: 5.1.0(postcss@8.4.49)
+      postcss-minify-gradients: 5.1.1(postcss@8.4.49)
+      postcss-minify-params: 5.1.4(postcss@8.4.49)
+      postcss-minify-selectors: 5.2.1(postcss@8.4.49)
+      postcss-normalize-charset: 5.1.0(postcss@8.4.49)
+      postcss-normalize-display-values: 5.1.0(postcss@8.4.49)
+      postcss-normalize-positions: 5.1.1(postcss@8.4.49)
+      postcss-normalize-repeat-style: 5.1.1(postcss@8.4.49)
+      postcss-normalize-string: 5.1.0(postcss@8.4.49)
+      postcss-normalize-timing-functions: 5.1.0(postcss@8.4.49)
+      postcss-normalize-unicode: 5.1.1(postcss@8.4.49)
+      postcss-normalize-url: 5.1.0(postcss@8.4.49)
+      postcss-normalize-whitespace: 5.1.1(postcss@8.4.49)
+      postcss-ordered-values: 5.1.3(postcss@8.4.49)
+      postcss-reduce-initial: 5.1.2(postcss@8.4.49)
+      postcss-reduce-transforms: 5.1.0(postcss@8.4.49)
+      postcss-svgo: 5.1.0(postcss@8.4.49)
+      postcss-unique-selectors: 5.1.1(postcss@8.4.49)
 
   cssnano-preset-default@6.1.2(postcss@8.4.35):
     dependencies:
@@ -17007,19 +17016,19 @@ snapshots:
       postcss-svgo: 6.0.3(postcss@8.4.35)
       postcss-unique-selectors: 6.0.4(postcss@8.4.35)
 
-  cssnano-utils@3.1.0(postcss@8.4.35):
+  cssnano-utils@3.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
 
   cssnano-utils@4.0.2(postcss@8.4.35):
     dependencies:
       postcss: 8.4.35
 
-  cssnano@5.1.15(postcss@8.4.35):
+  cssnano@5.1.15(postcss@8.4.49):
     dependencies:
-      cssnano-preset-default: 5.2.14(postcss@8.4.35)
+      cssnano-preset-default: 5.2.14(postcss@8.4.49)
       lilconfig: 2.1.0
-      postcss: 8.4.35
+      postcss: 8.4.49
       yaml: 1.10.2
 
   cssnano@6.1.2(postcss@8.4.35):
@@ -17684,7 +17693,7 @@ snapshots:
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3)(eslint@8.47.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.47.0)
       eslint-plugin-react: 7.33.2(eslint@8.47.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.47.0)
@@ -17707,7 +17716,7 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.47.0
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3)(eslint@8.47.0)
       get-tsconfig: 4.4.0
       globby: 13.1.3
       is-core-module: 2.13.1
@@ -17727,7 +17736,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0):
+  eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3)(eslint@8.47.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -17877,7 +17886,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -18805,9 +18814,9 @@ snapshots:
       safer-buffer: 2.1.2
     optional: true
 
-  icss-utils@5.1.0(postcss@8.4.35):
+  icss-utils@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
 
   ieee754@1.2.1: {}
 
@@ -19061,7 +19070,7 @@ snapshots:
 
   is-reference@3.0.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   is-regex@1.1.4:
     dependencies:
@@ -19287,7 +19296,7 @@ snapshots:
 
   launch-editor@2.6.1:
     dependencies:
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       shell-quote: 1.8.1
 
   levn@0.4.1:
@@ -19763,7 +19772,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.1
       micromark-factory-space: 2.0.0
@@ -19775,7 +19784,7 @@ snapshots:
   micromark-extension-mdx-jsx@3.0.0:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.1
@@ -19791,7 +19800,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
       micromark-util-character: 2.1.0
@@ -19827,7 +19836,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.1:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       devlop: 1.1.0
       micromark-util-character: 2.1.0
       micromark-util-events-to-acorn: 2.0.2
@@ -19891,7 +19900,7 @@ snapshots:
   micromark-util-events-to-acorn@2.0.2:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/unist': 3.0.2
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -20614,9 +20623,9 @@ snapshots:
 
   optimize-css-assets-webpack-plugin@6.0.1(webpack@4.47.0):
     dependencies:
-      cssnano: 5.1.15(postcss@8.4.35)
+      cssnano: 5.1.15(postcss@8.4.49)
       last-call-webpack-plugin: 3.0.0
-      postcss: 8.4.35
+      postcss: 8.4.49
       webpack: 4.47.0
 
   optionator@0.9.3:
@@ -20893,9 +20902,9 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.1.0
 
-  postcss-calc@8.2.4(postcss@8.4.35):
+  postcss-calc@8.2.4(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-selector-parser: 6.1.0
       postcss-value-parser: 4.2.0
 
@@ -20931,12 +20940,12 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@5.3.1(postcss@8.4.35):
+  postcss-colormin@5.3.1(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-colormin@6.1.0(postcss@8.4.35):
@@ -20947,10 +20956,10 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@5.1.3(postcss@8.4.35):
+  postcss-convert-values@5.1.3(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@6.1.0(postcss@8.4.35):
@@ -20989,33 +20998,33 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.1.0
 
-  postcss-discard-comments@5.1.2(postcss@8.4.35):
+  postcss-discard-comments@5.1.2(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
 
   postcss-discard-comments@6.0.2(postcss@8.4.35):
     dependencies:
       postcss: 8.4.35
 
-  postcss-discard-duplicates@5.1.0(postcss@8.4.35):
+  postcss-discard-duplicates@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
 
   postcss-discard-duplicates@6.0.3(postcss@8.4.35):
     dependencies:
       postcss: 8.4.35
 
-  postcss-discard-empty@5.1.1(postcss@8.4.35):
+  postcss-discard-empty@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
 
   postcss-discard-empty@6.0.3(postcss@8.4.35):
     dependencies:
       postcss: 8.4.35
 
-  postcss-discard-overridden@5.1.0(postcss@8.4.35):
+  postcss-discard-overridden@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
 
   postcss-discard-overridden@6.0.2(postcss@8.4.35):
     dependencies:
@@ -21093,11 +21102,11 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-merge-longhand@5.1.7(postcss@8.4.35):
+  postcss-merge-longhand@5.1.7(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
-      stylehacks: 5.1.1(postcss@8.4.35)
+      stylehacks: 5.1.1(postcss@8.4.49)
 
   postcss-merge-longhand@6.0.5(postcss@8.4.35):
     dependencies:
@@ -21105,12 +21114,12 @@ snapshots:
       postcss-value-parser: 4.2.0
       stylehacks: 6.1.1(postcss@8.4.35)
 
-  postcss-merge-rules@5.1.4(postcss@8.4.35):
+  postcss-merge-rules@5.1.4(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
       caniuse-api: 3.0.0
-      cssnano-utils: 3.1.0(postcss@8.4.35)
-      postcss: 8.4.35
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-selector-parser: 6.1.0
 
   postcss-merge-rules@6.1.1(postcss@8.4.35):
@@ -21121,9 +21130,9 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.1.0
 
-  postcss-minify-font-values@5.1.0(postcss@8.4.35):
+  postcss-minify-font-values@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-minify-font-values@6.1.0(postcss@8.4.35):
@@ -21131,11 +21140,11 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@5.1.1(postcss@8.4.35):
+  postcss-minify-gradients@5.1.1(postcss@8.4.49):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 3.1.0(postcss@8.4.35)
-      postcss: 8.4.35
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@6.0.3(postcss@8.4.35):
@@ -21145,11 +21154,11 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@5.1.4(postcss@8.4.35):
+  postcss-minify-params@5.1.4(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
-      cssnano-utils: 3.1.0(postcss@8.4.35)
-      postcss: 8.4.35
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-minify-params@6.1.0(postcss@8.4.35):
@@ -21159,9 +21168,9 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@5.2.1(postcss@8.4.35):
+  postcss-minify-selectors@5.2.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-selector-parser: 6.1.0
 
   postcss-minify-selectors@6.0.4(postcss@8.4.35):
@@ -21169,26 +21178,26 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.1.0
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.4.35):
+  postcss-modules-extract-imports@3.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
 
-  postcss-modules-local-by-default@4.0.5(postcss@8.4.35):
+  postcss-modules-local-by-default@4.0.5(postcss@8.4.49):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.35)
-      postcss: 8.4.35
+      icss-utils: 5.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-selector-parser: 6.1.0
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.0(postcss@8.4.35):
+  postcss-modules-scope@3.2.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-selector-parser: 6.1.0
 
-  postcss-modules-values@4.0.0(postcss@8.4.35):
+  postcss-modules-values@4.0.0(postcss@8.4.49):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.35)
-      postcss: 8.4.35
+      icss-utils: 5.1.0(postcss@8.4.49)
+      postcss: 8.4.49
 
   postcss-nesting@12.1.5(postcss@8.4.35):
     dependencies:
@@ -21197,17 +21206,17 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.1.0
 
-  postcss-normalize-charset@5.1.0(postcss@8.4.35):
+  postcss-normalize-charset@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
 
   postcss-normalize-charset@6.0.2(postcss@8.4.35):
     dependencies:
       postcss: 8.4.35
 
-  postcss-normalize-display-values@5.1.0(postcss@8.4.35):
+  postcss-normalize-display-values@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-display-values@6.0.2(postcss@8.4.35):
@@ -21215,9 +21224,9 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@5.1.1(postcss@8.4.35):
+  postcss-normalize-positions@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@6.0.2(postcss@8.4.35):
@@ -21225,9 +21234,9 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@5.1.1(postcss@8.4.35):
+  postcss-normalize-repeat-style@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-repeat-style@6.0.2(postcss@8.4.35):
@@ -21235,9 +21244,9 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@5.1.0(postcss@8.4.35):
+  postcss-normalize-string@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@6.0.2(postcss@8.4.35):
@@ -21245,9 +21254,9 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@5.1.0(postcss@8.4.35):
+  postcss-normalize-timing-functions@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-timing-functions@6.0.2(postcss@8.4.35):
@@ -21255,10 +21264,10 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@5.1.1(postcss@8.4.35):
+  postcss-normalize-unicode@5.1.1(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@6.1.0(postcss@8.4.35):
@@ -21267,10 +21276,10 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@5.1.0(postcss@8.4.35):
+  postcss-normalize-url@5.1.0(postcss@8.4.49):
     dependencies:
       normalize-url: 6.1.0
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-url@6.0.2(postcss@8.4.35):
@@ -21278,9 +21287,9 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@5.1.1(postcss@8.4.35):
+  postcss-normalize-whitespace@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize-whitespace@6.0.2(postcss@8.4.35):
@@ -21292,10 +21301,10 @@ snapshots:
     dependencies:
       postcss: 8.4.35
 
-  postcss-ordered-values@5.1.3(postcss@8.4.35):
+  postcss-ordered-values@5.1.3(postcss@8.4.49):
     dependencies:
-      cssnano-utils: 3.1.0(postcss@8.4.35)
-      postcss: 8.4.35
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-ordered-values@6.0.2(postcss@8.4.35):
@@ -21387,11 +21396,11 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.1.0
 
-  postcss-reduce-initial@5.1.2(postcss@8.4.35):
+  postcss-reduce-initial@5.1.2(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
       caniuse-api: 3.0.0
-      postcss: 8.4.35
+      postcss: 8.4.49
 
   postcss-reduce-initial@6.1.0(postcss@8.4.35):
     dependencies:
@@ -21399,9 +21408,9 @@ snapshots:
       caniuse-api: 3.0.0
       postcss: 8.4.35
 
-  postcss-reduce-transforms@5.1.0(postcss@8.4.35):
+  postcss-reduce-transforms@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-reduce-transforms@6.0.2(postcss@8.4.35):
@@ -21423,9 +21432,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@5.1.0(postcss@8.4.35):
+  postcss-svgo@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
 
@@ -21435,9 +21444,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
-  postcss-unique-selectors@5.1.1(postcss@8.4.35):
+  postcss-unique-selectors@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-selector-parser: 6.1.0
 
   postcss-unique-selectors@6.0.4(postcss@8.4.35):
@@ -22688,10 +22697,10 @@ snapshots:
       client-only: 0.0.1
       react: 18.3.1
 
-  stylehacks@5.1.1(postcss@8.4.35):
+  stylehacks@5.1.1(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
-      postcss: 8.4.35
+      postcss: 8.4.49
       postcss-selector-parser: 6.1.0
 
   stylehacks@6.1.1(postcss@8.4.35):
@@ -22775,7 +22784,7 @@ snapshots:
       css-select: 4.2.1
       css-tree: 1.1.3
       csso: 4.2.0
-      picocolors: 1.0.0
+      picocolors: 1.1.1
       stable: 0.1.8
 
   svgo@3.3.2:
@@ -22786,7 +22795,7 @@ snapshots:
       css-tree: 2.3.1
       css-what: 6.1.0
       csso: 5.0.5
-      picocolors: 1.0.0
+      picocolors: 1.1.1
 
   synckit@0.8.5:
     dependencies:
@@ -23206,25 +23215,25 @@ snapshots:
     dependencies:
       browserslist: 4.21.3
       escalade: 3.1.1
-      picocolors: 1.0.0
+      picocolors: 1.1.1
 
   update-browserslist-db@1.0.13(browserslist@4.22.2):
     dependencies:
       browserslist: 4.22.2
       escalade: 3.1.1
-      picocolors: 1.0.0
+      picocolors: 1.1.1
 
   update-browserslist-db@1.0.13(browserslist@4.23.0):
     dependencies:
       browserslist: 4.23.0
       escalade: 3.1.1
-      picocolors: 1.0.0
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.1(browserslist@4.24.2):
     dependencies:
       browserslist: 4.24.2
       escalade: 3.2.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   update-notifier@5.1.0:
     dependencies:
@@ -23332,7 +23341,7 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vike-node@0.2.1(encoding@0.1.13)(vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2))))(vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2))):
+  vike-node@0.2.1(encoding@0.1.13)(vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)):
     dependencies:
       '@brillout/picocolors': 1.0.15
       '@nitedani/shrink-ray-current': 4.3.0
@@ -23343,8 +23352,8 @@ snapshots:
       resolve-from: 5.0.0
       sirv: 2.0.4
       unenv-nightly: 2.0.0-20241015-162228-03257ee
-      vike: 0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2)))
-      vite: 5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2))
+      vike: 0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0))
+      vite: 6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -23386,7 +23395,7 @@ snapshots:
     optionalDependencies:
       react-streaming: 0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2))):
+  vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)):
     dependencies:
       '@brillout/import': 0.2.3
       '@brillout/json-serializer': 0.5.13
@@ -23400,7 +23409,7 @@ snapshots:
       fast-glob: 3.2.12
       semver: 7.6.0
       source-map-support: 0.5.21
-      vite: 5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2))
+      vite: 6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)
     optionalDependencies:
       react-streaming: 0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
@@ -23462,16 +23471,6 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.10.0(acorn@8.11.2)
 
-  vite@5.4.11(@types/node@22.10.1)(terser@5.10.0(acorn@8.11.2)):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.28.0
-    optionalDependencies:
-      '@types/node': 22.10.1
-      fsevents: 2.3.3
-      terser: 5.10.0(acorn@8.11.2)
-
   vite@5.4.6(@types/node@20.11.17)(terser@5.10.0(acorn@8.11.2)):
     dependencies:
       esbuild: 0.21.5
@@ -23480,6 +23479,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.11.17
       fsevents: 2.3.3
+      terser: 5.10.0(acorn@8.11.2)
+
+  vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0):
+    dependencies:
+      esbuild: 0.24.0
+      postcss: 8.4.49
+      rollup: 4.28.0
+    optionalDependencies:
+      '@types/node': 22.10.1
+      fsevents: 2.3.3
+      jiti: 1.21.0
       terser: 5.10.0(acorn@8.11.2)
 
   vitefu@0.2.4(vite@4.2.1(@types/node@22.10.1)(terser@5.10.0)):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: ^0.4.206
         version: 0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0))
       vike-node:
-        specifier: ^0.2.1
-        version: 0.2.1(encoding@0.1.13)(vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0))
+        specifier: ^0.2.2
+        version: 0.2.2(encoding@0.1.13)(vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0))
       vite:
         specifier: ^6.0.2
         version: 6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)
@@ -10635,8 +10635,8 @@ packages:
   vfile@6.0.1:
     resolution: {integrity: sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==}
 
-  vike-node@0.2.1:
-    resolution: {integrity: sha512-Xw67m//2iXV8cy8g0z0vf/ASZ9nWCRTNSPyuz5SvgjU8Lk3Qlm/vJyrHhcTndFeiEItZ0pUy54JzafPvHGGdtg==}
+  vike-node@0.2.2:
+    resolution: {integrity: sha512-tLSYnDzrWoR8MKu7xuDn51c11UlwlxQrX88rnYJWV7hQ77KNT3OBOl3ITJlTBnlfgqN8vvMez6SvfM1biLpHlg==}
     peerDependencies:
       vike: ^0.4.198
       vite: '>=5.0.10'
@@ -17693,7 +17693,7 @@ snapshots:
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3)(eslint@8.47.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.47.0)
       eslint-plugin-react: 7.33.2(eslint@8.47.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.47.0)
@@ -17716,7 +17716,7 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.47.0
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3)(eslint@8.47.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0)
       get-tsconfig: 4.4.0
       globby: 13.1.3
       is-core-module: 2.13.1
@@ -17736,7 +17736,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3)(eslint@8.47.0):
+  eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.51.0(eslint@8.47.0)(typescript@5.1.6))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.29.0(eslint@8.47.0))(eslint@8.47.0))(eslint@8.47.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -20879,7 +20879,7 @@ snapshots:
     dependencies:
       jsonc-parser: 3.2.0
       mlly: 1.3.0
-      pathe: 1.1.1
+      pathe: 1.1.2
 
   playwright-chromium@1.25.1:
     dependencies:
@@ -23341,7 +23341,7 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vike-node@0.2.1(encoding@0.1.13)(vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)):
+  vike-node@0.2.2(encoding@0.1.13)(vike@0.4.206(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)))(vite@6.0.2(@types/node@22.10.1)(jiti@1.21.0)(terser@5.10.0)):
     dependencies:
       '@brillout/picocolors': 1.0.15
       '@nitedani/shrink-ray-current': 4.3.0


### PR DESCRIPTION
Vite 6 has a regression around resolving the imports of npm packages.

Error:

```
~/code/telefunc/examples/authentication (brillout/vite-6|u=) pnpm run dev

> @ dev /home/rom/code/telefunc/examples/authentication
> npm run server


> server
> vite

  VITE v6.0.2  ready in 789 ms
  ➜  press h + enter to show help
Server running at http://localhost:3000
✘ [ERROR] No known conditions for "./stringify" specifier in "@brillout/json-serializer" package [plugin vite:dep-pre-bundle]

    ../../telefunc/dist/cjs/node/server/runTelefunc/serializeTelefunctionResult.js:4:28:
      4 │ const stringify_1 = require("@brillout/json-serializer/stringify");
        ╵                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  This error came from the "onResolve" callback registered here:

    ../../node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:1150:20:
      1150 │       let promise = setup({
           ╵                     ^

    at setup (file:///home/rom/code/telefunc/node_modules/.pnpm/vite@6.0.2_@types+node@22.10.1_jiti@1.21.0_terser@5.10.0/node_modules/vite/dist/node/chunks/dep-A4nAWF7x.js:16602:13)
    at handlePlugins (/home/rom/code/telefunc/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:1150:21)
    at buildOrContextImpl (/home/rom/code/telefunc/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:873:5)
    at Object.buildOrContext (/home/rom/code/telefunc/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:699:5)
    at /home/rom/code/telefunc/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:2037:68
    at new Promise (<anonymous>)
    at Object.context (/home/rom/code/telefunc/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:2037:27)
    at Object.context (/home/rom/code/telefunc/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:1879:58)
    at prepareEsbuildOptimizerRun (file:///home/rom/code/telefunc/node_modules/.pnpm/vite@6.0.2_@types+node@22.10.1_jiti@1.21.0_terser@5.10.0/node_modules/vite/dist/node/chunks/dep-A4nAWF7x.js:18794:33)
```

Reproduction steps:

```bash
git clone git@github.com:brillout/telefunc
cd telefunc/
git checkout brillout/vite-6
pnpm install
pnpm run build
cd examples/authentication/
pnpm run dev
```

Same as single line (copy & paste me):

```bash
git clone git@github.com:brillout/telefunc && cd telefunc/ && git checkout brillout/vite-6 && pnpm install && pnpm run build && cd examples/authentication/ && pnpm run dev
```
