### PR TITLE
feat: add option for turning off shield in prod (closes #116)

### DIFF
--- a/docs/pages/shield-config/+Page.mdx
+++ b/docs/pages/shield-config/+Page.mdx
@@ -2,18 +2,20 @@ import { Link, Warning } from '@brillout/docpress'
 import { ConfigWhereServer } from '../../components'
 
 **Environment**: server.  
-**Default**: `false`.  
+**Type**: `boolean | { dev?: boolean; prod?: boolean }`.  
+**Default**: `{ dev: false, prod: true }`.  
 
-Whether to generate <Link href="/shield">`shield()`</Link> in development.
+Whether to generate <Link href="/shield">`shield()`</Link> in development and/or when building for production.
 
 ```js
 // Environment: server
 
 import { config } from 'telefunc'
 
+// Enable shield() generation during development
 config.shield.dev = true
 ```
 
-<Warning>This can slow down development speed. Depending on your app and how fast your computer is, the decreased development speed can range from unnoticeable to significant.</Warning>
+<Warning>Enabling `shield()` generation during development can significantly slow down development speed. Depending on how large your app and how fast your computer is, the decreased development speed can range from unnoticeable to significant.</Warning>
 
 <ConfigWhereServer />

--- a/telefunc/node/server/serverConfig.ts
+++ b/telefunc/node/server/serverConfig.ts
@@ -23,12 +23,15 @@ type ConfigUser = {
   root?: string
   /** Whether to disable ETag cache headers */
   disableEtag?: boolean
+  /**
+   * Config object to control shield generation during development/production
+   * or a simple boolean to it on/off completely. By default, it will be an
+   * object set to false for development and true for production.
+   */
   shield?: {
-    /** Whether to generate shield during development */
     dev?: boolean
-    /** Whether to generate shield during product. Default is set to true */
     prod?: boolean
-  }
+  } | boolean
   log?: {
     /** Whether to log shield errors */
     shieldErrors?:
@@ -47,7 +50,7 @@ type ConfigResolved = {
   disableEtag: boolean
   telefuncFiles: string[] | null
   disableNamingConvention: boolean
-  shield: { dev: boolean, prod: boolean }
+  shield: { dev: boolean, prod: boolean } | boolean
   log: {
     shieldErrors: { dev: boolean; prod: boolean }
   }
@@ -59,7 +62,7 @@ function getServerConfig(): ConfigResolved {
   return {
     disableEtag: configUser.disableEtag ?? false,
     disableNamingConvention: configUser.disableNamingConvention ?? false,
-    shield: { dev: configUser.shield?.dev ?? false, prod: configUser.shield?.prod ?? true },
+    shield: typeof configUser.shield === 'boolean' ? configUser.shield : { dev: configUser.shield?.dev ?? false, prod: configUser.shield?.prod ?? true },
     log: {
       shieldErrors: (() => {
         const shieldErrors = configUser.log?.shieldErrors ?? {}

--- a/telefunc/node/server/serverConfig.ts
+++ b/telefunc/node/server/serverConfig.ts
@@ -26,6 +26,8 @@ type ConfigUser = {
   shield?: {
     /** Whether to generate shield during development */
     dev?: boolean
+    /** Whether to generate shield during product. Default is set to true */
+    prod?: boolean
   }
   log?: {
     /** Whether to log shield errors */
@@ -45,7 +47,7 @@ type ConfigResolved = {
   disableEtag: boolean
   telefuncFiles: string[] | null
   disableNamingConvention: boolean
-  shield: { dev: boolean }
+  shield: { dev: boolean, prod: boolean }
   log: {
     shieldErrors: { dev: boolean; prod: boolean }
   }
@@ -57,7 +59,7 @@ function getServerConfig(): ConfigResolved {
   return {
     disableEtag: configUser.disableEtag ?? false,
     disableNamingConvention: configUser.disableNamingConvention ?? false,
-    shield: { dev: configUser.shield?.dev ?? false },
+    shield: { dev: configUser.shield?.dev ?? false, prod: configUser.shield?.prod ?? true },
     log: {
       shieldErrors: (() => {
         const shieldErrors = configUser.log?.shieldErrors ?? {}

--- a/telefunc/node/server/serverConfig.ts
+++ b/telefunc/node/server/serverConfig.ts
@@ -24,14 +24,19 @@ type ConfigUser = {
   /** Whether to disable ETag cache headers */
   disableEtag?: boolean
   /**
-   * Config object to control shield generation during development/production
-   * or a simple boolean to it on/off completely. By default, it will be an
-   * object set to false for development and true for production.
+   * Whether to generate shield.
+   *
+   * https://telefunc.com/shield-config
+   * https://telefunc.com/shield
+   *
+   * @default { dev: false, prod: true }
    */
-  shield?: {
-    dev?: boolean
-    prod?: boolean
-  } | boolean
+  shield?:
+    | {
+        dev?: boolean
+        prod?: boolean
+      }
+    | boolean
   log?: {
     /** Whether to log shield errors */
     shieldErrors?:
@@ -50,7 +55,7 @@ type ConfigResolved = {
   disableEtag: boolean
   telefuncFiles: string[] | null
   disableNamingConvention: boolean
-  shield: { dev: boolean, prod: boolean } | boolean
+  shield: { dev: boolean; prod: boolean }
   log: {
     shieldErrors: { dev: boolean; prod: boolean }
   }
@@ -62,7 +67,10 @@ function getServerConfig(): ConfigResolved {
   return {
     disableEtag: configUser.disableEtag ?? false,
     disableNamingConvention: configUser.disableNamingConvention ?? false,
-    shield: typeof configUser.shield === 'boolean' ? configUser.shield : { dev: configUser.shield?.dev ?? false, prod: configUser.shield?.prod ?? true },
+    shield:
+      typeof configUser.shield === 'boolean'
+        ? { dev: configUser.shield, prod: configUser.shield }
+        : { dev: configUser.shield?.dev ?? false, prod: configUser.shield?.prod ?? true },
     log: {
       shieldErrors: (() => {
         const shieldErrors = configUser.log?.shieldErrors ?? {}

--- a/telefunc/node/transformer/transformTelefuncFileServerSide.ts
+++ b/telefunc/node/transformer/transformTelefuncFileServerSide.ts
@@ -21,10 +21,10 @@ async function transformTelefuncFileServerSide(
 
   let codeShield: string | undefined
   const config = getServerConfig()
-  const shieldEnabled = typeof config.shield === 'boolean' 
+  const isShieldEnabled = typeof config.shield === 'boolean' 
     ? config.shield 
     : isDev ? config.shield.dev : config.shield.prod
-  if (id.endsWith('.ts') && shieldEnabled) {
+  if (id.endsWith('.ts') && isShieldEnabled) {
     codeShield = generateShield(src, id, appRootDir, exportList)
   }
 

--- a/telefunc/node/transformer/transformTelefuncFileServerSide.ts
+++ b/telefunc/node/transformer/transformTelefuncFileServerSide.ts
@@ -21,7 +21,10 @@ async function transformTelefuncFileServerSide(
 
   let codeShield: string | undefined
   const config = getServerConfig()
-  if (id.endsWith('.ts') && ((isDev && config.shield.dev) || (!isDev && config.shield.prod))) {
+  const shieldEnabled = typeof config.shield === 'boolean' 
+    ? config.shield 
+    : isDev ? config.shield.dev : config.shield.prod
+  if (id.endsWith('.ts') && shieldEnabled) {
     codeShield = generateShield(src, id, appRootDir, exportList)
   }
 

--- a/telefunc/node/transformer/transformTelefuncFileServerSide.ts
+++ b/telefunc/node/transformer/transformTelefuncFileServerSide.ts
@@ -21,7 +21,7 @@ async function transformTelefuncFileServerSide(
 
   let codeShield: string | undefined
   const config = getServerConfig()
-  if (id.endsWith('.ts') && (!isDev || config.shield.dev)) {
+  if (id.endsWith('.ts') && ((isDev && config.shield.dev) || (!isDev && config.shield.prod))) {
     codeShield = generateShield(src, id, appRootDir, exportList)
   }
 

--- a/telefunc/node/transformer/transformTelefuncFileServerSide.ts
+++ b/telefunc/node/transformer/transformTelefuncFileServerSide.ts
@@ -21,9 +21,7 @@ async function transformTelefuncFileServerSide(
 
   let codeShield: string | undefined
   const config = getServerConfig()
-  const isShieldEnabled = typeof config.shield === 'boolean' 
-    ? config.shield 
-    : isDev ? config.shield.dev : config.shield.prod
+  const isShieldEnabled = isDev ? config.shield.dev : config.shield.prod
   if (id.endsWith('.ts') && isShieldEnabled) {
     codeShield = generateShield(src, id, appRootDir, exportList)
   }


### PR DESCRIPTION
Adding an option for turning off shield for prod builds because generating shields absolutely chews through my RAM.

<img width="1810" alt="Screenshot 2025-04-21 at 5 16 17 PM" src="https://github.com/user-attachments/assets/09d208ea-c912-4321-970c-a2bbec4b5fb2" />


Note: I did not get a chance to test this. I followed the contribution guide but couldn't get my environment working.
