### PR TITLE
docs: add React Router Docs

### DIFF
--- a/docs/+redirects.ts
+++ b/docs/+redirects.ts
@@ -10,5 +10,5 @@ type RedirectsURL = RemoveHash<(typeof redirects)[keyof typeof redirects]>
 checkType<HeadingsURL>(0 as any as RedirectsURL)
 
 const redirects = {
-  // TODO
+  '/remix': '/react-router'
 } as const satisfies Config['redirects']

--- a/docs/+redirects.ts
+++ b/docs/+redirects.ts
@@ -1,0 +1,14 @@
+export { redirects }
+
+import type { Config } from 'vike/types'
+import type { HeadingsURL } from './headings'
+import { checkType } from './utils/checkType'
+
+// Use TypeScript to check whether redirect targets point to an existing page
+type RemoveHash<T extends string> = T extends `${infer Path}#${string}` ? Path : T
+type RedirectsURL = RemoveHash<(typeof redirects)[keyof typeof redirects]>
+checkType<HeadingsURL>(0 as any as RedirectsURL)
+
+const redirects = {
+  // TODO
+} as const satisfies Config['redirects']

--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -25,30 +25,30 @@ const headingsDetached = [...misc()] satisfies HeadingDetachedDefinition[]
 function misc() {
   return (
     [
-  {
-    title: '`Abort()` vs `new Error()`',
-    url: '/abort-vs-error',
-  },
-  {
-    title: 'Telefunc Transformer',
-    url: '/transformer',
-  },
-  {
-    title: 'RPC vs GraphQL/REST',
-    url: '/RPC-vs-GraphQL-REST',
-  },
-  {
-    title: 'Initial Page Data',
-    url: '/initial-page-data',
-  },
-  {
-    title: 'Initial Data',
-    url: '/initial-data',
-  },
-  {
-    title: 'Multiple Clients',
-    url: '/multiple-clients',
-  },
+      {
+        title: '`Abort()` vs `new Error()`',
+        url: '/abort-vs-error',
+      },
+      {
+        title: 'Telefunc Transformer',
+        url: '/transformer',
+      },
+      {
+        title: 'RPC vs GraphQL/REST',
+        url: '/RPC-vs-GraphQL-REST',
+      },
+      {
+        title: 'Initial Page Data',
+        url: '/initial-page-data',
+      },
+      {
+        title: 'Initial Data',
+        url: '/initial-data',
+      },
+      {
+        title: 'Multiple Clients',
+        url: '/multiple-clients',
+      },
     ] as const
   ).map((h) => ({ ...h, category: 'Miscellaneous' as const })) satisfies HeadingDetachedDefinition[]
 }

--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -1,13 +1,30 @@
 export { categories }
 export { headings }
 export { headingsDetached }
+export type { HeadingsURL }
 
-import type { Config, HeadingDefinition, HeadingDetachedDefinition } from '@brillout/docpress'
+import type {
+  Config,
+  HeadingDefinition,
+  HeadingDetachedDefinition as HeadingDetachedDefinition_,
+} from '@brillout/docpress'
 import { iconScroll, iconCompass, iconGear, iconSeedling } from '@brillout/docpress'
+type HeadingDetachedDefinition = Omit<HeadingDetachedDefinition_, 'category'> & {
+  category: CategoryNames | 'Miscellaneous'
+}
 
-const categories: Config['categories'] = ['Guides', 'API', 'Get Started', 'Overview']
+type ExtractHeadingUrl<C> = C extends { url: infer N extends string } ? N : C extends string ? C : never
+type HeadingsURL = ExtractHeadingUrl<(typeof headings)[number]> | ExtractHeadingUrl<(typeof headingsDetached)[number]>
+type ExtractCategoryName<C> = C extends { name: infer N extends string } ? N : C extends string ? C : never
+type CategoryNames = ExtractCategoryName<(typeof categories)[number]>
 
-const headingsDetached: HeadingDetachedDefinition[] = [
+const categories = ['Guides', 'API', 'Get Started', 'Overview', 'Miscellaneous'] as const satisfies Config['categories']
+
+const headingsDetached = [...misc()] satisfies HeadingDetachedDefinition[]
+
+function misc() {
+  return (
+    [
   {
     title: '`Abort()` vs `new Error()`',
     url: '/abort-vs-error',
@@ -32,9 +49,11 @@ const headingsDetached: HeadingDetachedDefinition[] = [
     title: 'Multiple Clients',
     url: '/multiple-clients',
   },
-]
+    ] as const
+  ).map((h) => ({ ...h, category: 'Miscellaneous' as const })) satisfies HeadingDetachedDefinition[]
+}
 
-const headings: HeadingDefinition[] = [
+const headings = [
   {
     level: 1,
     title: 'Overview',
@@ -249,4 +268,4 @@ const headings: HeadingDefinition[] = [
     title: 'Babel Plugin',
     url: '/babel-plugin',
   },
-]
+] as const satisfies HeadingDefinition[]

--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -104,11 +104,6 @@ const headings = [
   },
   {
     level: 2,
-    title: 'Remix',
-    url: '/remix',
-  },
-  {
-    level: 2,
     title: 'React Router',
     url: '/react-router',
   },

--- a/docs/headings.ts
+++ b/docs/headings.ts
@@ -90,6 +90,11 @@ const headings: HeadingDefinition[] = [
   },
   {
     level: 2,
+    title: 'React Router',
+    url: '/react-router',
+  },
+  {
+    level: 2,
     title: 'Other installations',
     titleInNav: 'Other',
     url: '/install',

--- a/docs/pages/react-router/+Page.mdx
+++ b/docs/pages/react-router/+Page.mdx
@@ -1,4 +1,7 @@
 import { Example } from '../../components'
 
-Example of using Telefunc with [React Router](https://reactrouter.com/):
+Example of using Telefunc with [React Router](https://reactrouter.com):
  - <Example timestamp="09.2025" repo="arnaudsm/telefunc-react-router-demo" />
+
+Example with [Remix](https://remix.run) (React Router was [formerly known as Remix](https://remix.run/blog/merging-remix-and-react-router)):
+ - <Example timestamp="06.2024" repo="overshom/remix-telefunc-demo" />

--- a/docs/pages/react-router/+Page.mdx
+++ b/docs/pages/react-router/+Page.mdx
@@ -1,0 +1,4 @@
+import { Example } from '../../components'
+
+Example of using Telefunc with [React Router](https://reactrouter.com/):
+ - <Example timestamp="09.2025" repo="arnaudsm/telefunc-react-router-demo" />

--- a/docs/pages/remix/+Page.mdx
+++ b/docs/pages/remix/+Page.mdx
@@ -2,3 +2,5 @@ import { Example } from '../../components'
 
 Example of using Telefunc with [Remix](https://remix.run/):
  - <Example timestamp="06.2024" repo="overshom/remix-telefunc-demo" />
+
+Note that [Remix merged into React Router 7](https://reactrouter.com/upgrading/remix), which [also works](/react-router) with Telefunc.

--- a/docs/pages/remix/+Page.mdx
+++ b/docs/pages/remix/+Page.mdx
@@ -1,6 +1,0 @@
-import { Example } from '../../components'
-
-Example of using Telefunc with [Remix](https://remix.run/):
- - <Example timestamp="06.2024" repo="overshom/remix-telefunc-demo" />
-
-Note that [Remix merged into React Router 7](https://reactrouter.com/upgrading/remix), which [also works](/react-router) with Telefunc.

--- a/docs/utils/checkType.ts
+++ b/docs/utils/checkType.ts
@@ -1,0 +1,1 @@
+export function checkType<Type>(_: Type) {}


### PR DESCRIPTION
Following discussion in #212, here's documentation about the React-Router support and example, since Remix got merged into it.